### PR TITLE
Bug Fix: Only apply snap helper if on fling listener is null on th…

### DIFF
--- a/app/src/main/java/dj/dynamic/card/view/adapter/VerticalRecyclerViewAdapter.kt
+++ b/app/src/main/java/dj/dynamic/card/view/adapter/VerticalRecyclerViewAdapter.kt
@@ -57,8 +57,10 @@ class VerticalRecyclerViewAdapter(
         if (!cardGroups[position].is_scrollable &&
             fullScreenWidthCardTypes.contains(cardGroups[position].design_type)
         ) {
-            val snapHelper = PagerSnapHelper()
-            snapHelper.attachToRecyclerView(view.horizontalRecyclerView)
+            if (view.horizontalRecyclerView.onFlingListener == null) {
+                val snapHelper = PagerSnapHelper()
+                snapHelper.attachToRecyclerView(view.horizontalRecyclerView)
+            }
         }
 
         weakActivityContext.get()?.let { activityContext ->


### PR DESCRIPTION
Bug Fix: Only apply snap helper if on fling listener is null on the horizontal recycler view. This check fixes the crash(An instance of onFlingListener already set in RecyclerView) observed when the user scrolls down in the vertical RecyclerView of the app.